### PR TITLE
Drastically improve check performance

### DIFF
--- a/core/src/main/java/me/xneox/epicguard/core/check/AbstractCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/AbstractCheck.java
@@ -16,6 +16,7 @@
 package me.xneox.epicguard.core.check;
 
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 import me.xneox.epicguard.core.EpicGuard;
 import me.xneox.epicguard.core.user.ConnectingUser;
@@ -59,19 +60,23 @@ public abstract sealed class AbstractCheck implements Comparable<AbstractCheck>
 
     /**
      * This method asserts the following behaviour based on the provided {@link ToggleState}:
-     * - If the state is ALWAYS, it will return the value of the specified expression.
-     * - If the state is ATTACK, it will return the value of the expression ONLY if there's an attack.
+     * - If the state is ALWAYS, it will evaluate and return the value of the specified expression.
+     * - If the state is ATTACK, it will evaluate and return the value of the expression ONLY if there's an attack.
      * - If the state is NEVER, it will return false.
+     * <br/>
+     * This method invokes the expression sync, so it is advised
+     * to put all expensive operations inside the expression.
      *
      * @param state      the configured {@link ToggleState} for this check
-     * @param expression the base check's result
+     * @param expression the base check runnable if the state is met
      * @return The return value is based on the check's behaviour. True means positive detection,
      * false means negative.
      */
-    public boolean evaluate(ToggleState state, boolean expression) {
+    public boolean evaluate(ToggleState state, BooleanSupplier expression) {
         if (state == ToggleState.ALWAYS || state == ToggleState.ATTACK && this.epicGuard.attackManager().isUnderAttack()) {
-            return expression;
+            return expression.getAsBoolean();
         }
+
         return false;
     }
 

--- a/core/src/main/java/me/xneox/epicguard/core/check/AccountLimitCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/AccountLimitCheck.java
@@ -31,6 +31,6 @@ public final class AccountLimitCheck extends AbstractCheck {
   public boolean isDetected(@NotNull ConnectingUser user) {
     var accounts = this.epicGuard.storageManager().addressMeta(user.address()).nicknames();
     return this.evaluate(this.epicGuard.config().accountLimitCheck().checkMode(),
-        !accounts.contains(user.nickname()) && accounts.size() >= this.epicGuard.config().accountLimitCheck().accountLimit());
+            () -> !accounts.contains(user.nickname()) && accounts.size() >= this.epicGuard.config().accountLimitCheck().accountLimit());
   }
 }

--- a/core/src/main/java/me/xneox/epicguard/core/check/GeographicalCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/GeographicalCheck.java
@@ -29,7 +29,7 @@ public final class GeographicalCheck extends AbstractCheck {
 
   @Override
   public boolean isDetected(@NotNull ConnectingUser user) {
-    return this.evaluate(this.epicGuard.config().geographical().checkMode(), this.isRestricted(user.address()));
+    return this.evaluate(this.epicGuard.config().geographical().checkMode(), () -> this.isRestricted(user.address()));
   }
 
   private boolean isRestricted(String address) {

--- a/core/src/main/java/me/xneox/epicguard/core/check/NicknameCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/NicknameCheck.java
@@ -30,6 +30,6 @@ public final class NicknameCheck extends AbstractCheck {
   @Override
   public boolean isDetected(@NotNull ConnectingUser user) {
     return this.evaluate(this.epicGuard.config().nicknameCheck().checkMode(),
-        user.nickname().matches(this.epicGuard.config().nicknameCheck().expression()));
+            () -> user.nickname().matches(this.epicGuard.config().nicknameCheck().expression()));
   }
 }

--- a/core/src/main/java/me/xneox/epicguard/core/check/ProxyCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/ProxyCheck.java
@@ -31,6 +31,6 @@ public final class ProxyCheck extends AbstractCheck {
   @Override
   public boolean isDetected(@NotNull ConnectingUser user) {
     return this.evaluate(this.epicGuard.config().proxyCheck().checkMode(),
-        this.epicGuard.proxyManager().isProxy(user.address()));
+            () -> this.epicGuard.proxyManager().isProxy(user.address()));
   }
 }

--- a/core/src/main/java/me/xneox/epicguard/core/check/ReconnectCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/ReconnectCheck.java
@@ -34,7 +34,8 @@ public final class ReconnectCheck extends AbstractCheck {
 
   @Override
   public boolean isDetected(@NotNull ConnectingUser user) {
-    return this.evaluate(this.epicGuard.config().reconnectCheck().checkMode(), this.needsReconnect(user));
+    return this.evaluate(this.epicGuard.config().reconnectCheck().checkMode(),
+            () -> this.needsReconnect(user));
   }
 
   private boolean needsReconnect(ConnectingUser connectingUser) {

--- a/core/src/main/java/me/xneox/epicguard/core/check/ServerListCheck.java
+++ b/core/src/main/java/me/xneox/epicguard/core/check/ServerListCheck.java
@@ -30,6 +30,6 @@ public final class ServerListCheck extends AbstractCheck {
   @Override
   public boolean isDetected(@NotNull ConnectingUser user) {
     return this.evaluate(this.epicGuard.config().serverListCheck().checkMode(),
-        !this.epicGuard.storageManager().pingCache().contains(user.address()));
+            () -> !this.epicGuard.storageManager().pingCache().contains(user.address()));
   }
 }


### PR DESCRIPTION
It makes sense to only calculate checks when they are actually enabled! Can save a lot of processing time when some checks are disabled.