### PR TITLE
Add ip tab completion disable option

### DIFF
--- a/core/src/main/java/me/xneox/epicguard/core/command/sub/AnalyzeCommand.java
+++ b/core/src/main/java/me/xneox/epicguard/core/command/sub/AnalyzeCommand.java
@@ -17,6 +17,8 @@ package me.xneox.epicguard.core.command.sub;
 
 import com.google.common.net.InetAddresses;
 import java.util.Collection;
+import java.util.Collections;
+
 import me.xneox.epicguard.core.EpicGuard;
 import me.xneox.epicguard.core.command.SubCommand;
 import me.xneox.epicguard.core.util.TextUtils;
@@ -68,6 +70,10 @@ public class AnalyzeCommand implements SubCommand {
 
   @Override
   public @NotNull Collection<String> suggest(@NotNull String[] args, @NotNull EpicGuard epicGuard) {
+    if (epicGuard.config().misc().disableIPTabCompletion()) {
+      return Collections.emptyList();
+    }
+
     return epicGuard.storageManager().addresses().asMap().keySet();
   }
 }

--- a/core/src/main/java/me/xneox/epicguard/core/command/sub/BlacklistCommand.java
+++ b/core/src/main/java/me/xneox/epicguard/core/command/sub/BlacklistCommand.java
@@ -68,7 +68,8 @@ public class BlacklistCommand implements SubCommand {
       return List.of("add", "remove");
     }
 
-    if (args[1].equalsIgnoreCase("remove")) {
+    if (args[1].equalsIgnoreCase("remove")
+            && !epicGuard.config().misc().disableIPTabCompletion()) {
       return epicGuard.storageManager().viewAddresses(AddressMeta::blacklisted);
     }
     return Collections.emptyList();

--- a/core/src/main/java/me/xneox/epicguard/core/command/sub/WhitelistCommand.java
+++ b/core/src/main/java/me/xneox/epicguard/core/command/sub/WhitelistCommand.java
@@ -68,9 +68,11 @@ public class WhitelistCommand implements SubCommand {
       return List.of("add", "remove");
     }
 
-    if (args[1].equalsIgnoreCase("remove")) {
+    if (args[1].equalsIgnoreCase("remove")
+            && !epicGuard.config().misc().disableIPTabCompletion()) {
       return epicGuard.storageManager().viewAddresses(AddressMeta::whitelisted);
     }
+
     return Collections.emptyList();
   }
 }

--- a/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
+++ b/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
@@ -400,7 +400,7 @@ public class PluginConfiguration {
     private long attackResetInterval = 80L;
 
     @Comment("Disable IPs in tab completion.")
-    private boolean disableIPTabCompletion = true;
+    private boolean disableIPTabCompletion = false;
 
     @Comment("Set to false to disable update checker.")
     private boolean updateChecker = true;

--- a/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
+++ b/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
@@ -400,7 +400,7 @@ public class PluginConfiguration {
     private long attackResetInterval = 80L;
 
     @Comment("Disable IPs in tab completion.")
-    private boolean disableIPTabCompletion = false;
+    private boolean disableIpTabCompletion = false;
 
     @Comment("Set to false to disable update checker.")
     private boolean updateChecker = true;
@@ -429,7 +429,7 @@ public class PluginConfiguration {
     }
 
     public boolean disableIPTabCompletion() {
-      return this.disableIPTabCompletion;
+      return this.disableIpTabCompletion;
     }
 
     public boolean updateChecker() {

--- a/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
+++ b/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
@@ -399,6 +399,9 @@ public class PluginConfiguration {
             (!) Requires restart to apply.""")
     private long attackResetInterval = 80L;
 
+    @Comment("Disable IPs in tab completion.")
+    private boolean disableIPTabCompletion = true;
+
     @Comment("Set to false to disable update checker.")
     private boolean updateChecker = true;
 
@@ -423,6 +426,10 @@ public class PluginConfiguration {
 
     public long attackResetInterval() {
       return this.attackResetInterval;
+    }
+
+    public boolean disableIPTabCompletion() {
+      return this.disableIPTabCompletion;
     }
 
     public boolean updateChecker() {


### PR DESCRIPTION
In case someone gets access to tab completion using incorrectly working plugins, we want to have this option to prevent them from easily retrieving a list of IPs.