### PR TITLE
Change default to disable IP tab completion.

### DIFF
--- a/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
+++ b/core/src/main/java/me/xneox/epicguard/core/config/PluginConfiguration.java
@@ -400,7 +400,7 @@ public class PluginConfiguration {
     private long attackResetInterval = 80L;
 
     @Comment("Disable IPs in tab completion.")
-    private boolean disableIpTabCompletion = false;
+    private boolean disableIpTabCompletion = true;
 
     @Comment("Set to false to disable update checker.")
     private boolean updateChecker = true;


### PR DESCRIPTION
The safe option should always be the default one.

Tyranny of the default - people never change their configs.