### PR TITLE
Don't send data if the connection is invalid

### DIFF
--- a/waterfall/src/main/java/me/xneox/epicguard/waterfall/listener/ServerPingListener.java
+++ b/waterfall/src/main/java/me/xneox/epicguard/waterfall/listener/ServerPingListener.java
@@ -31,6 +31,7 @@ public class ServerPingListener extends PingHandler implements Listener {
 
     if(event.getConnection() == null) {
       event.setResponse(null);
+      return;
     }
 
     //noinspection deprecation

--- a/waterfall/src/main/java/me/xneox/epicguard/waterfall/listener/ServerPingListener.java
+++ b/waterfall/src/main/java/me/xneox/epicguard/waterfall/listener/ServerPingListener.java
@@ -28,6 +28,11 @@ public class ServerPingListener extends PingHandler implements Listener {
 
   @EventHandler(priority = Byte.MIN_VALUE)
   public void onPing(ProxyPingEvent event) {
+
+    if(event.getConnection() == null) {
+      event.setResponse(null);
+    }
+
     //noinspection deprecation
     this.onPing(event.getConnection().getAddress().getAddress().getHostAddress());
   }


### PR DESCRIPTION
In high connections per second and even more if they are corrupted, they can send a lot of data and saturate the traffic and resources of the proxy.

This can help alleviate that problem